### PR TITLE
"append" function in MARRMoT_model.m replaced with "strcat"

### DIFF
--- a/MARRMoT/Models/Model files/MARRMoT_model.m
+++ b/MARRMoT/Models/Model files/MARRMoT_model.m
@@ -548,11 +548,10 @@ classdef MARRMoT_model < handle
                          i = find(diff(cal_idx(i:end)) ~= 1, 1) + i - 1;
                          if isempty(i); i = numel(cal_idx); end
                          previous = cal_idx(i);
-                         cal_idx_str = append(cal_idx_str, '-', num2str(previous));
                      else
                          previous = cal_idx(i);
-                         cal_idx_str = append(cal_idx_str, ', ', num2str(previous));
                      end
+					 cal_idx_str = strcat(cal_idx_str, '-', num2str(previous));
                  end
     
                  disp(['Objective function ' of_name ' will be calculated in time steps ' cal_idx_str '.'])

--- a/MARRMoT/Models/Model files/MARRMoT_model.m
+++ b/MARRMoT/Models/Model files/MARRMoT_model.m
@@ -548,10 +548,12 @@ classdef MARRMoT_model < handle
                          i = find(diff(cal_idx(i:end)) ~= 1, 1) + i - 1;
                          if isempty(i); i = numel(cal_idx); end
                          previous = cal_idx(i);
+                         cal_idx_str = strcat(cal_idx_str, '-', num2str(previous));
                      else
                          previous = cal_idx(i);
+                         cal_idx_str = strcat(cal_idx_str, ', ', num2str(previous));
                      end
-					 cal_idx_str = strcat(cal_idx_str, '-', num2str(previous));
+					 
                  end
     
                  disp(['Objective function ' of_name ' will be calculated in time steps ' cal_idx_str '.'])


### PR DESCRIPTION
There are two "append" functions called at lines 551 and 554 in file MARRMoT_model.m. "Append" function was not available prior to Matlab R2019a (see [https://www.mathworks.com/help/matlab/ref/append.html](https://www.mathworks.com/help/matlab/ref/append.html)). This function breaks MARRMoT calibration process, although it is a simple string concatenation, for Matlab versions prior to R2019a and Octave (all versions). I only replaced "append" with traditional "strcat" function to fix this issue. 