### PR TITLE
fixed optional inputs into logistic smoother

### DIFF
--- a/MARRMoT/Functions/Flux smoothing/smoothThreshold_storage_logistic.m
+++ b/MARRMoT/Functions/Flux smoothing/smoothThreshold_storage_logistic.m
@@ -35,7 +35,11 @@ if nargin == 2
     r = 0.01;
     e = 5.00;
 elseif nargin == 3
+    r = r{1};
     e = 5.00;
+elseif nargin == 4
+    r = r{1};
+    e = e{1};
 end
 
 % Calculate multiplier


### PR DESCRIPTION
minor fix: optional input into the logistic smoother are received as cells, not float. This should now be fixed. 

Fix does not affect outcomes of workflow examples 1-4 (as it shouldn't).