### PR TITLE
bugfix: ensure no percolation if store is in deficit mode

### DIFF
--- a/MARRMoT/Models/Flux files/percolation_6.m
+++ b/MARRMoT/Models/Flux files/percolation_6.m
@@ -16,7 +16,7 @@ function [out] = percolation_6(p1,p2,S,dt)
 %               S    - current storage [mm]
 %               dt   - time step size [d]
 
-out = min(S/dt,p1.*min(1,max(0,S)./p2));
+out = min(max(0,S)/dt,p1.*min(1,max(0,S)./p2));
 
 end
 


### PR DESCRIPTION
Closes #61 

Added an extra constraint to ensure flux only returns values with non-negative deficits (i.e., water surplus):

Included test against known solution: the piece-wise function described in #61:
```
% function inputs
D = linspace(-1,1,201);
delta_t = 1;

% specify parameters as used in the Q0.05 pyMARRMoT comparison runs
dsurp   = 100.95;   % theta(6)
qpmax   = 1;        % theta(9)

% true solution
qp_true = zeros(1,length(D));
for i = 1:length(D)
    d = D(i);
    if d >= dsurp
        out = min(d/delta_t,qpmax);
    elseif d < 0
        out = 0;
    else
        out = min(d/delta_t,qpmax*d/dsurp);
    end
    qp_true(i) = out;
end
```

![image](https://github.com/user-attachments/assets/4eb07e59-9b6a-45c4-b2e9-0d323e68073c)
